### PR TITLE
Update factory.py to work for batch of images

### DIFF
--- a/onepose/models/factory.py
+++ b/onepose/models/factory.py
@@ -1,7 +1,10 @@
 import numpy as np
+import cv2
 import torch
 import torch.nn as nn
 import onepose.models.vitpose as vitpose
+from PIL import Image
+
 from onepose.utils import read_cfg, download_weights
 from onepose.transforms import ComposeTransforms, BGR2RGB, TopDownAffine, ToTensor, NormalizeTensor, _box2cs
 from onepose.functional import keypoints_from_heatmaps
@@ -105,51 +108,82 @@ class Model(nn.Module):
 
     @torch.no_grad()
     @torch.inference_mode()
-    def forward(self, x: Union[List[np.ndarray], np.ndarray]) -> np.ndarray:
+    def forward(self, x: Union[np.ndarray, Image.Image, List[Union[np.ndarray, Image.Image]]]) -> Union[Dict, List[Dict]]:
         if self.training:
             self.eval()
-
+        
         device = next(self.parameters()).device
-
-        if isinstance(x, np.ndarray):
+        
+        single_image = False
+        # Input validation and conversion
+        if isinstance(x, list):
+            if not x:  # empty list check
+                raise ValueError("Input list cannot be empty")
+            if not all(isinstance(img, (np.ndarray, Image.Image)) for img in x):
+                raise TypeError("All elements in the list must be either numpy arrays or PIL Images")
+            # Convert PIL images to numpy arrays with BGR color space
+            x = [cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR) if isinstance(img, Image.Image) else img for img in x]
+        elif isinstance(x, (np.ndarray, Image.Image)):
+            if isinstance(x, Image.Image):
+                x = cv2.cvtColor(np.array(x), cv2.COLOR_RGB2BGR)
             x = [x]
-        batch_size = len(x)
+            single_image = True
+        else:
+            raise TypeError("Input must be either a numpy array, PIL Image, or a list of them")
+        
+        # Convert grayscale images to BGR
+        for i, img in enumerate(x):
+            if img.ndim == 2 or (img.ndim == 3 and img.shape[2] == 1):
+                x[i] = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
-        img_height, img_width = x[0].shape[:2]
-        center, scale = _box2cs(self.model_cfg.data_cfg['image_size'], [0, 0, img_width, img_height])
+        batch_results = []
+        for img in x:
+            img_height, img_width = img.shape[:2]
+            center, scale = _box2cs(self.model_cfg.data_cfg['image_size'], 
+                                [0, 0, img_width, img_height])      
 
-        results = {'img': x,
-                   'rotation': 0,
-                   'center': center,
-                   'scale': scale,
-                   'image_size': np.array(self.model_cfg.data_cfg['image_size']),
-                   }
+            results = {
+                'img': img,
+                'rotation': 0,
+                'center': center,
+                'scale': scale,
+                'image_size': np.array(self.model_cfg.data_cfg['image_size']),
+            }
 
-        results = self.transforms(results)
-        batch_images = torch.stack(results["img"], dim=0).to(device)
-        #results['img'] = results['img'].to(device)
+            results = self.transforms(results)
+            batch_results.append(results['img'])
 
-        #out = self.model(results['img'][None, ...])
-        out = self.model(batch_images)
+        # Stack transformed images into a batch
+        batch_tensor = torch.stack(batch_results).to(device)
+        
+        # Forward pass
+        out = self.model(batch_tensor)
         out = out.cpu().numpy()
-
-        out, maxvals = keypoints_from_heatmaps(out,
-                                      center=np.tile(center, (batch_size, 1)),
-                                      scale=np.tile(scale, (batch_size, 1)),
-                                      unbiased=False,
-                                      post_process='default',
-                                      kernel=11,
-                                      valid_radius_factor=0.0546875,
-                                      use_udp=self.use_udp,
-                                      target_type='GaussianHeatmap')
-
-        # To keep compatibility with the original single image implementation
-        if batch_size == 1:
-            out = out[0]
-            maxvals = maxvals[0]
-
-        out = {'points': out, 'confidence': maxvals}
-        return out
+        
+        # Process each image's predictions
+        centers = [_box2cs(self.model_cfg.data_cfg['image_size'], 
+                        [0, 0, img.shape[1], img.shape[0]])[0] for img in x]
+        scales = [_box2cs(self.model_cfg.data_cfg['image_size'], 
+                        [0, 0, img.shape[1], img.shape[0]])[1] for img in x]
+        
+        points, maxvals = keypoints_from_heatmaps(
+            out,
+            center=centers,
+            scale=scales,
+            unbiased=False,
+            post_process='default',
+            kernel=11,
+            valid_radius_factor=0.0546875,
+            use_udp=self.use_udp,
+            target_type='GaussianHeatmap'
+        )
+        
+        outputs = [{'points': p, 'confidence': c} for p, c in zip(points, maxvals)]
+        
+        # Return single result for single image input
+        if single_image:
+            return outputs[0]
+        return outputs
 
 def create_model(model_name: str = 'ViTPose_huge_simple_coco') -> Model:
     model = Model(model_name=model_name)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ from setuptools import find_packages, setup
 setup(
     name='onepose',
     version='1.0',
-    install_requires=['opencv-python', 'torch', 'torchvision', 'tqdm', 'numpy'],
+    install_requires=['opencv-python', 'torch', 'torchvision', 'tqdm', 'numpy', 'Pillow'],
     packages=find_packages(exclude='notebooks')
 )


### PR DESCRIPTION
## Description

The current implementation supports sending one image at a time. In some applications, sending a batch of images through the model and leveraging the GPU capabilities to speed up the processing would be useful. I have made slight modifications to the "forward" function in "factory.py" in the "models" folder. Now it accepts a single image or a list of images and do batch processing.

## Tests
I tested it using the following code and it checks out
import cv2
import onepose
```
if __name__ == "__main__":
   
    model = onepose.create_model("ViTPose+_base_coco_wholebody")
    img1 = cv2.imread('/path/to/image1')
    img2 = cv2.imread('/path/to/image2')
    
    batch_img = [img1, img2]
    keypoints = model(img1)
    keypoints_batch = model(batch_img)
```
    
